### PR TITLE
Fix/install walkthrough

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ See `run.sh` for an example invocation of the scripts above and integration with
 Walkthrough
 -----------
 
-An overview of all steps required to implement an instance of osm-analytics can be found [here](https://gist.github.com/tyrasd/5f17d10a5b9ab1c8d2409238a5e0a54b) (work in progress)
+An overview of all steps required to implement an instance of osm-analytics can be found [here](https://github.com/GFDRR/osm-analytics-cruncher/blob/notippecanoe/documentation/setup_walkthrough.md) (work in progress)

--- a/crunch-all.sh
+++ b/crunch-all.sh
@@ -15,7 +15,7 @@
 # config
 WORKING_DIR=/mnt/data
 RESULTS_DIR=~/results
-SERVER_SCRIPT=/home/ubuntu/server/serve.js
+SERVER_SCRIPT=./server/serve.js
 
 PLANET=$1
 

--- a/crunch-all.sh
+++ b/crunch-all.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -ex
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# this is an example script for how to invoke  osm-analytics-cruncher to
+# regenerate vector tiles for osm-analytics from osm-qa-tiles
+#
+# config parameters:
+# * WORKING_DIR - working directory where intermediate data is stored
+#                 (requires at least around ~160 GB for planet wide calc.)
+# * RESULTS_DIR - directory where resulting .mbtiles files are stored
+# * SERVER_SCRIPT - node script that serves the .mbtiles (assumed to be already
+#                   started with `forever`)
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+# config
+WORKING_DIR=/mnt/data
+RESULTS_DIR=~/results
+SERVER_SCRIPT=/home/ubuntu/server/serve.js
+
+PLANET=$1
+
+# clean up
+trap cleanup EXIT
+function cleanup {
+  rm -rf $WORKING_DIR/osm-analytics-cruncher
+}
+
+# generate user experience data
+./experiences.sh planet.mbtiles
+
+# buildings
+./crunch.sh $PLANET buildings 64
+cp buildings.mbtiles $RESULTS_DIR/buildings.mbtiles.tmp
+mv -f $RESULTS_DIR/buildings.mbtiles.tmp $RESULTS_DIR/buildings.mbtiles
+forever restart $SERVER_SCRIPT
+rm buildings.mbtiles
+
+# highways
+./crunch.sh $PLANET highways 32
+cp highways.mbtiles $RESULTS_DIR/highways.mbtiles.tmp
+mv -f $RESULTS_DIR/highways.mbtiles.tmp $RESULTS_DIR/highways.mbtiles
+forever restart $SERVER_SCRIPT
+rm highways.mbtiles
+
+# waterways
+./crunch.sh $PLANET waterways 32
+cp waterways.mbtiles $RESULTS_DIR/waterways.mbtiles.tmp
+mv -f $RESULTS_DIR/waterways.mbtiles.tmp $RESULTS_DIR/waterways.mbtiles
+forever restart $SERVER_SCRIPT
+rm waterways.mbtiles

--- a/crunch-all.sh
+++ b/crunch-all.sh
@@ -26,7 +26,7 @@ function cleanup {
 }
 
 # generate user experience data
-./experiences.sh planet.mbtiles
+./experiences.sh $PLANET
 
 # buildings
 ./crunch.sh $PLANET buildings 64

--- a/documentation/setup_walkthrough.md
+++ b/documentation/setup_walkthrough.md
@@ -1,0 +1,44 @@
+# Cruncher
+
+* install node/npm, curl
+* compile and install [tippecanoe](https://github.com/mapbox/tippecanoe) (version 1.8.1 works, not sure about newer releases)
+* download [`run.sh`](https://raw.githubusercontent.com/hotosm/osm-analytics-cruncher/master/run.sh) from cruncher repo
+* replace osmqatiles-planet url with the extract you want
+* adjust paths in `crunch-all.sh` (and mkdir the respective working directories)
+* comment out `hotprojects.sh` (would fail because it requires valid AWS credentials to upload stuff into a hardcoded bucket).
+* comment out the `forever restart …` lines (requires a tile-serving script to be already running)
+* or install `forever` globally (`npm i -g forever`), and run `forever server/serve.js` (before running the cruncher)
+* execute `run.sh` -> … -> two `.mbtiles` files in results directory
+
+# Serve Results
+
+There are some options:
+
+* use [mb-util](https://github.com/mapbox/mbutil) (e.g. `mb-util --image_format=pbf buildings.mbtile buildings`) to unpack mbtiles file and serve it via a local web server (or upload the data to S3, or …).
+* use mapbox-tile-copy to upload contents directly to S3
+* use a server script like the [example](https://github.com/hotosm/osm-analytics-cruncher/blob/master/server/serve.js) in the repo that serves tiles directly from the mbtiles file. (code needs to be adjusted!)
+
+HTTP API schema is:
+
+    http://.../.../<feature-type>/<z>/<x>/<y>.pbf
+
+where `feature-type` is buildings,highways, etc.
+
+The web server needs to return proper `CORS` headers, the `Content-Encoding=gzip` header (!) and the `Content-Type` header needs to be either `application/x-protobuf` or `application/octet-stream`.
+
+# Run frontend
+
+* clone repo `git clone https://github.com/hotosm/osm-analytics`
+* run `npm install`
+* adjust base-url setting in `./app/settings/settings.js`
+* run `npm start` (for a development-server) or `npm run build` to build a production build (results as HTML5 in `./static`)
+
+# Add a new feature type
+
+(not yet tested, sorry)
+
+* on frontend side: add new type in `./app/settings/options.js` (as entry in `filters` array)
+* on backend:
+  * add new type definition json file (like [`buildings.json`](https://github.com/hotosm/osm-analytics-cruncher/blob/master/buildings.json)) (use `"objects"` as a generic user-experience field)
+  * add a new [crunching section in `run.sh`](https://github.com/hotosm/osm-analytics-cruncher/blob/58fdf84582dc6593fa7b2fcae8850ba10db62453/run.sh#L42-L48) for the newly created feature type
+  * serve results (see above)

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "simple-statistics": "^2.4.0",
     "sphericalmercator": "^1.0.4",
     "superagent": "^1.8.3",
+    "tile-reduce": "^3.1.1",
     "turf": "^2.0.2",
     "vt-pbf": "^2.1.2"
   }

--- a/run.sh
+++ b/run.sh
@@ -1,22 +1,5 @@
 #!/bin/bash -ex
 
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-# this is an example script for how to invoke  osm-analytics-cruncher to
-# regenerate vector tiles for osm-analytics from osm-qa-tiles
-#
-# config parameters:
-# * WORKING_DIR - working directory where intermediate data is stored
-#                 (requires at least around ~160 GB for planet wide calc.)
-# * RESULTS_DIR - directory where resulting .mbtiles files are stored
-# * SERVER_SCRIPT - node script that serves the .mbtiles (assumed to be already
-#                   started with `forever`)
-# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
-
-# config
-WORKING_DIR=/mnt/data
-RESULTS_DIR=~/results
-SERVER_SCRIPT=/home/ubuntu/server/serve.js
-
 # clean up
 trap cleanup EXIT
 function cleanup {
@@ -35,30 +18,7 @@ npm install --silent
 # download latest planet from osm-qa-tiles
 curl https://s3.amazonaws.com/mapbox/osm-qa-tiles/latest.planet.mbtiles.gz --silent | gzip -d > planet.mbtiles
 
-# generate user experience data
-./experiences.sh planet.mbtiles
-
 # generate osm-analytics data
-# buildings
-./crunch.sh planet.mbtiles buildings 64
-cp buildings.mbtiles $RESULTS_DIR/buildings.mbtiles.tmp
-rm $RESULTS_DIR/buildings.mbtiles -f
-mv $RESULTS_DIR/buildings.mbtiles.tmp $RESULTS_DIR/buildings.mbtiles
-forever restart $SERVER_SCRIPT
-rm buildings.mbtiles
-# highways
-./crunch.sh planet.mbtiles highways 32
-cp highways.mbtiles $RESULTS_DIR/highways.mbtiles.tmp
-rm $RESULTS_DIR/highways.mbtiles -f
-mv $RESULTS_DIR/highways.mbtiles.tmp $RESULTS_DIR/highways.mbtiles
-forever restart $SERVER_SCRIPT
-rm highways.mbtiles
-# waterways
-./crunch.sh planet.mbtiles waterways 32
-cp waterways.mbtiles $RESULTS_DIR/waterways.mbtiles.tmp
-rm $RESULTS_DIR/waterways.mbtiles -f
-mv $RESULTS_DIR/waterways.mbtiles.tmp $RESULTS_DIR/waterways.mbtiles
-forever restart $SERVER_SCRIPT
-rm waterways.mbtiles
+./crunch-all.sh planet.mbtiles
 
 rm planet.mbtiles


### PR DESCRIPTION
- adds missing tile-reduce dependency
- moves the bulk of the crunching operations outside of run.sh (makes testing easier)
- moves edited instructions from https://gist.github.com/tyrasd/5f17d10a5b9ab1c8d2409238a5e0a54b to this repo

Fixes https://github.com/hotosm/osm-analytics-cruncher/issues/12